### PR TITLE
Add powerups, shield mechanic, and improve save/load

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -27,7 +27,7 @@ function loadProgress(){
 function hasSaveSlot(){ return !!localStorage.getItem('space_save_slot'); }
 function saveGameState(){
   try{
-    const slot = { best, credits, owned:[...owned], selectedShipId, difficulty, player, bullets, asteroids, enemies, enemyBullets, score, currentLevel, currentWave, waveState, elapsed, lastShotAt };
+    const slot = { best, credits, owned:[...owned], selectedShipId, difficulty, player, bullets, asteroids, enemies, enemyBullets, powerups, score, currentLevel, currentWave, waveState, elapsed, lastShotAt, state };
     localStorage.setItem('space_save_slot', JSON.stringify(slot));
   }catch(e){}
 }
@@ -38,17 +38,21 @@ function loadGameState(){
     best = +s.best || 0; credits = +s.credits || 0; owned = new Set(Array.isArray(s.owned)?s.owned:['scout']);
     selectedShipId = SHIPS.some(sh=>sh.id===s.selectedShipId) ? s.selectedShipId : 'scout';
     difficulty = DIFFS[s.difficulty] ? s.difficulty : 'medium';
-    player = s.player || {x:WIDTH/2,y:HEIGHT-80,r:PLAYER_R,maxHp:110,hp:110,iTime:0};
+    player = s.player || {x:WIDTH/2,y:HEIGHT-80,r:PLAYER_R,maxHp:110,hp:110,iTime:0,shield:0};
+    if (player.shield === undefined) player.shield = 0;
     bullets = Array.isArray(s.bullets)? s.bullets : [];
     asteroids = Array.isArray(s.asteroids)? s.asteroids : [];
     enemies = Array.isArray(s.enemies)? s.enemies : [];
     enemyBullets = Array.isArray(s.enemyBullets)? s.enemyBullets : [];
-    score = +s.score || 0; 
-    currentLevel = +s.currentLevel || 1; 
+    powerups = Array.isArray(s.powerups)? s.powerups : [];
+    score = +s.score || 0;
+    currentLevel = +s.currentLevel || 1;
     currentWave = +s.currentWave || 1;
     waveState = s.waveState || 'preparing';
-    elapsed = +s.elapsed || 0; 
+    elapsed = +s.elapsed || 0;
     lastShotAt = +s.lastShotAt || -999;
-    saveProgress(); return true;
+    const st = s.state || 'playing';
+    saveProgress();
+    return st;
   }catch(e){ return false; }
 }


### PR DESCRIPTION
## Summary
- Remove global turquoise flash when firing by clearing bullet and particle shadows
- Add collectible health and shield powerups dropped by destroyed asteroids or enemies
- Ensure newly purchased ships start at full HP and saving/loading respects game state

## Testing
- `node --check game.js`
- `node --check storage.js`


------
https://chatgpt.com/codex/tasks/task_e_6899b98be2888333bfd5638462ca4c4d