### PR TITLE
Configure NSIS installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
   },
   "build": {
     "appId": "space.mini",
-    "productName": "Space Mini"
+    "productName": "Space Mini",
+    "win": {
+      "target": "nsis"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "createDesktopShortcut": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- enable Windows NSIS installer with desktop shortcut option

## Testing
- `npm test`
- `npm run build` *(fails: cannot move downloaded into final location)*

------
https://chatgpt.com/codex/tasks/task_e_689a64e4a76483338bec772a16dad278