### PR TITLE
Adjust upgrade cost, hangar navigation, and powerup duration

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -29,7 +29,7 @@ const WAVES_PER_LEVEL = 3;
 
 // Ship upgrade system
 const MAX_SHIP_LEVEL = 3;
-const UPGRADE_COSTS = [0, 200, 500]; // index by target level
+const UPGRADE_COSTS = [0, 200, 500, 1000]; // index by target level
 
 /* ===========================
    Enemy Types

--- a/game.js
+++ b/game.js
@@ -161,7 +161,10 @@ function toMain(){
 }
 function validateSelected(){ if (!SHIPS.some(s=>s.id===selectedShipId)) selectedShipId='scout'; }
 function toHangar(returnTo='mainmenu'){ validateSelected(); hangarReturn = returnTo; transitionTo('hangar'); }
-function backFromHangar(){ if (hangarReturn === 'levelcomplete') transitionTo('levelcomplete'); else toMain(); }
+function backFromHangar(){
+  if (hangarReturn === 'mainmenu') toMain();
+  else transitionTo(hangarReturn);
+}
 function toSettings(){ transitionTo('settings'); }
 
 function resetGame(){
@@ -491,7 +494,7 @@ function update(dt){
     if (circleHit(player.x,player.y,player.r, p.x,p.y,p.r)){
       if (p.type === 'hp'){ player.hp = Math.min(player.maxHp, player.hp + 30); }
       else if (p.type === 'shield'){ player.shield = 2; }
-      else if (p.type === 'rainbow'){ player.rainbowTime = Math.max(player.rainbowTime, 5); }
+      else if (p.type === 'rainbow'){ player.rainbowTime = Math.max(player.rainbowTime, 8); }
       powerups.splice(i,1);
       playSfx(880,'sine',0.1,0.1);
     }


### PR DESCRIPTION
## Summary
- Make upgrading to level 3 cost 1000 credits
- Return to the originating menu when leaving the hangar
- Extend rainbow power-up duration for a longer boost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689af4ca067c8333be6814b711b5a9e9