### PR TITLE
Add info screen listing ships and bosses

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -169,6 +169,6 @@ function stopMusic(){
   }, 700);
 }
 
-function wantMenuMusic(){ return ['mainmenu','hangar','settings','paused','gameover'].includes(state); }
+function wantMenuMusic(){ return ['mainmenu','hangar','settings','paused','gameover','info'].includes(state); }
 function refreshMusic(){ if (!musicOn){ stopMusic(); return; } if (wantMenuMusic()) startMusic(); else stopMusic(); }
 

--- a/constants.js
+++ b/constants.js
@@ -69,34 +69,47 @@ const ENEMY_TYPES = {
    Ships with Visual Designs
    =========================== */
 const SHIPS = [
-  { 
-    id:'scout', name:'SCOUT', cost:0, 
+  {
+    id:'scout', name:'SCOUT', cost:0,
+    desc:'Balanced starter ship.',
     stats:{ hp:110, speedMul:1.00, cooldownMul:1.00, bulletMul:1.00 },
     colors: { primary:'#00dcff', secondary:'#0099cc', core:'#66efff', thruster:'#00aaff' }
   },
-  { 
-    id:'raptor', name:'RAPTOR', cost:150, 
+  {
+    id:'raptor', name:'RAPTOR', cost:150,
+    desc:'Faster firing assault craft.',
     stats:{ hp:140, speedMul:1.05, cooldownMul:0.85, bulletMul:1.00 },
     colors: { primary:'#ff6600', secondary:'#cc4400', core:'#ffaa00', thruster:'#ff8800' }
   },
-  { 
-    id:'nova', name:'NOVA', cost:400, 
+  {
+    id:'nova', name:'NOVA', cost:400,
+    desc:'Upgraded cannons pack a punch.',
     stats:{ hp:170, speedMul:1.10, cooldownMul:0.70, bulletMul:1.10 },
     colors: { primary:'#aa00ff', secondary:'#6600aa', core:'#dd55ff', thruster:'#cc44ff' }
   },
-  { 
-    id:'zenith', name:'ZENITH', cost:1000, 
+  {
+    id:'zenith', name:'ZENITH', cost:1000,
+    desc:'Elite fighter with rapid fire.',
     stats:{ hp:200, speedMul:1.15, cooldownMul:0.55, bulletMul:1.15 },
     colors: { primary:'#ffaa00', secondary:'#cc7700', core:'#ffdd44', thruster:'#ffcc22' }
   },
   {
     id:'aurora', name:'AURORA', cost:2000,
+    desc:'Advanced craft with powerful guns.',
     stats:{ hp:240, speedMul:1.22, cooldownMul:0.45, bulletMul:1.20 },
     colors: { primary:'#00ffaa', secondary:'#00cc77', core:'#55ffcc', thruster:'#22ffaa' }
   },
   {
     id:'eclipse', name:'ECLIPSE', cost:3500,
+    desc:'Top tier ship for seasoned pilots.',
     stats:{ hp:280, speedMul:1.30, cooldownMul:0.35, bulletMul:1.25 },
     colors: { primary:'#ff00aa', secondary:'#cc0088', core:'#ff55cc', thruster:'#ff0099' }
   },
+];
+
+const BOSSES = [
+  { type:'MINIBOSS', name:'Miniboss', desc:'Tough mid-wave foe.' },
+  { type:'BOSS3', name:'Sector 3 Boss', desc:'Rotating guardian.' },
+  { type:'BOSS6', name:'Sector 6 Boss', desc:'Shielded warship.' },
+  { type:'BOSS9', name:'Final Boss', desc:'The ultimate challenge.' },
 ];

--- a/game.js
+++ b/game.js
@@ -166,6 +166,7 @@ function backFromHangar(){
   else transitionTo(hangarReturn);
 }
 function toSettings(){ transitionTo('settings'); }
+function toInfo(){ transitionTo('info'); }
 
 function resetGame(){
   bullets.length = 0; asteroids.length = 0; particles.length = 0; trail.length = 0; thrusterParticles.length = 0;
@@ -421,6 +422,7 @@ function onKeyDown(e){
     if (state==='paused') return resumeGame();
     if (state==='hangar') return backFromHangar();
     if (state==='settings') return toMain();
+    if (state==='info') return toMain();
   }
 
   if (state==='playing'){
@@ -886,6 +888,7 @@ function render(){
 
   drawHUD();
   if (state==='mainmenu') drawMainMenu();
+  if (state==='info') drawInfo();
   if (state==='hangar') drawHangar();
   if (state==='settings') drawSettings();
   if (state==='paused') drawPause();
@@ -1472,11 +1475,118 @@ function drawMainMenu(){
   drawButton(WIDTH/2-140, 276, 280, 44, hasSaveSlot()?'Load Game':'Load Game (empty)', ()=>{ const st=loadGameState(); if(st){ transitionTo(st); if(state==='levelcomplete') levelCompleteTime=3; } }, !hasSaveSlot());
   drawButton(WIDTH/2-140, 332, 280, 44, 'Settings', ()=>{ toSettings(); });
   drawButton(WIDTH/2-140, 388, 280, 44, 'Hangar', ()=>{ toHangar(); });
+  drawButton(WIDTH/2-140, 444, 280, 44, 'Info', ()=>{ toInfo(); });
 
   ctx.fillStyle='rgba(180,220,240,0.7)'; ctx.font='14px system-ui, sans-serif';
   ctx.fillText('5 Levels • 3 Waves Each • Epic Boss Battles', WIDTH/2, HEIGHT-40);
   ctx.fillText('Click once to enable audio', WIDTH/2, HEIGHT-20);
 }
+function drawInfo(){
+  ctx.fillStyle='rgba(0,0,10,0.65)'; ctx.fillRect(0,0,WIDTH,HEIGHT);
+  ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=COLORS.hud;
+  ctx.font='bold 46px system-ui, sans-serif'; ctx.fillText('Info', WIDTH/2, 70);
+
+  ctx.textAlign='left'; ctx.font='bold 20px system-ui, sans-serif';
+  let y=110; ctx.fillText('Ships',40,y); y+=20;
+  ctx.font='14px system-ui, sans-serif'; ctx.textBaseline='middle';
+  for (let ship of SHIPS){
+    y+=34;
+    ctx.save(); ctx.translate(60,y-10); ctx.scale(0.7,0.7);
+    const colors=ship.colors;
+    switch(ship.id){
+      case 'scout': drawScoutShip(colors); break;
+      case 'raptor': drawRaptorShip(colors); break;
+      case 'nova': drawNovaShip(colors); break;
+      case 'zenith': drawZenithShip(colors); break;
+      case 'aurora': drawAuroraShip(colors); break;
+      case 'eclipse': drawEclipseShip(colors); break;
+      default: drawScoutShip(colors); break;
+    }
+    ctx.restore();
+    ctx.fillText(`${ship.name}: ${ship.desc}`,100,y);
+  }
+
+  y+=20; ctx.font='bold 20px system-ui, sans-serif'; ctx.fillText('Bosses',40,y); y+=20;
+  ctx.font='14px system-ui, sans-serif';
+  for (let boss of BOSSES){
+    y+=34;
+    drawBossPreview(boss.type,60,y-10);
+    ctx.fillText(`${boss.name}: ${boss.desc}`,100,y);
+  }
+
+  drawButton(WIDTH/2-100, HEIGHT-60, 200, 44, 'Back', ()=>{ toMain(); });
+}
+
+function drawBossPreview(type,x,y){
+  const info = ENEMY_TYPES[type];
+  const size = info.size, color = info.color;
+  ctx.save();
+  ctx.translate(x,y);
+  ctx.fillStyle = color + '60';
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.shadowColor = color;
+  ctx.shadowBlur = 10;
+
+  ctx.beginPath();
+  ctx.moveTo(0,-size);
+  ctx.lineTo(-size*0.8,0);
+  ctx.lineTo(0,size);
+  ctx.lineTo(size*0.8,0);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  if (type==='BOSS3'){
+    ctx.save();
+    ctx.strokeStyle='#fff';
+    ctx.lineWidth=2;
+    ctx.beginPath();
+    for (let i=0;i<3;i++){
+      const ang=i*2*Math.PI/3;
+      const r=size*1.1;
+      const x=Math.cos(ang)*r;
+      const y=Math.sin(ang)*r;
+      if (i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+  } else if (type==='BOSS6'){
+    ctx.strokeStyle='#fff';
+    ctx.lineWidth=2;
+    ctx.beginPath();
+    ctx.arc(0,0,size*1.3,0,Math.PI*2);
+    ctx.stroke();
+  } else if (type==='BOSS9'){
+    ctx.save();
+    ctx.strokeStyle='#fff';
+    ctx.lineWidth=2;
+    ctx.beginPath();
+    for (let i=0;i<5;i++){
+      const ang=i*2*Math.PI/5;
+      const outerR=size*1.5;
+      const innerR=size*0.7;
+      const x1=Math.cos(ang)*outerR;
+      const y1=Math.sin(ang)*outerR;
+      const ang2=ang+Math.PI/5;
+      const x2=Math.cos(ang2)*innerR;
+      const y2=Math.sin(ang2)*innerR;
+      if (i===0) ctx.moveTo(x1,y1); else ctx.lineTo(x1,y1);
+      ctx.lineTo(x2,y2);
+    }
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  ctx.fillStyle = color;
+  ctx.shadowBlur = 8;
+  ctx.beginPath(); ctx.arc(-size*0.4, size*0.5, 3, 0, Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.arc(size*0.4, size*0.5, 3, 0, Math.PI*2); ctx.fill();
+  ctx.restore();
+}
+
 function drawSettings(){
   ctx.fillStyle='rgba(0,0,10,0.65)'; ctx.fillRect(0,0,WIDTH,HEIGHT);
   ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=COLORS.hud;


### PR DESCRIPTION
## Summary
- Add Info option to main menu
- Show all ships and bosses with art and short descriptions
- Include Info screen in menu music flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b04a48dd88333b1b54c4ab43c42a6