### PR TITLE
Include game scripts in Android build

### DIFF
--- a/copy-static.js
+++ b/copy-static.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const files = ['constants.js', 'audio.js', 'storage.js', 'game.js', 'service-worker.js'];
+const distDir = path.join(__dirname, 'dist');
+
+for (const file of files) {
+  const src = path.join(__dirname, file);
+  const dest = path.join(distDir, file);
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, dest);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron .",
     "dev:web": "vite",
-    "build:web": "vite build",
+    "build:web": "vite build && node copy-static.js",
     "preview:web": "vite preview",
     "build": "electron-builder",
     "build:android": "powershell -ExecutionPolicy RemoteSigned ./build-and-install.ps1",


### PR DESCRIPTION
## Summary
- copy game JavaScript files into the `dist` directory after building
- update web build script to run the copy step, ensuring Android WebView loads all assets

## Testing
- `npm run build:web`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e51b7d7608333946a1e2fdd148b1c