### PR TITLE
Improve mobile layout and add pause control

### DIFF
--- a/game.js
+++ b/game.js
@@ -1428,6 +1428,9 @@ function drawHUD(){
     ctx.fillStyle='rgba(0,20,30,0.7)'; roundRect(HPX,HPY,HPW,HPH,6); ctx.fill();
     ctx.fillStyle= pct<0.3 ? '#ff7a7a' : '#7af'; roundRect(HPX,HPY,HPW*pct,HPH,6); ctx.fill();
     ctx.fillStyle=COLORS.hud; ctx.fillText(`HP ${Math.ceil(player.hp)}/${player.maxHp}`, HPX, HPY-18);
+
+    // Pause button for touch devices
+    drawButton(WIDTH-90, HEIGHT-50, 80, 40, 'Pause', ()=>{ pauseGame(); }, false, true);
   } else if (state === 'hangar'){
     ctx.textAlign='right'; hudChip(WIDTH-10,10,`Credits: ${credits}`, true);
   }

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 html, body { margin:0; height:100%; background:#05070c; color:#c8f6ff; font:16px/1.35 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-#wrap { display:grid; place-items:center; height:100%;
+#wrap { display:grid; place-items:center; width:100vw; height:100vh;
   background: radial-gradient(1200px 700px at 20% 10%, #0a1630 0%, rgba(10,22,48,0) 60%),
               radial-gradient(1200px 700px at 80% 90%, #140a30 0%, rgba(20,10,48,0) 60%); }
 canvas { background:#000; display:block; border-radius:16px; box-shadow:
@@ -8,5 +8,11 @@ canvas { background:#000; display:block; border-radius:16px; box-shadow:
   0 0 120px rgba(120, 0, 255, .06);
   cursor: default;
   touch-action: none;
+  width:100%;
+  height:100%;
+  max-width:100vw;
+  max-height:100vh;
+  object-fit:contain;
 }
+#app-links { position:fixed; bottom:10px; left:10px; }
 


### PR DESCRIPTION
## Summary
- Scale game canvas to fit viewport and avoid clipping on mobile
- Add on-screen pause button to access existing pause menu on touch devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5706a74c83339e2c372352f92416