### PR TITLE
Lock landscape orientation and adjust level complete menu heading

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="landscape">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/game.js
+++ b/game.js
@@ -388,7 +388,7 @@ function showLevelComplete(){
     const sp = randRange(60,140);
     levelCompleteParticles.push({
       x: WIDTH/2,
-      y: HEIGHT/2 - 80,
+      y: HEIGHT/2 - 120,
       vx: Math.cos(a)*sp,
       vy: Math.sin(a)*sp,
       life: randRange(0.8,1.6),
@@ -1778,7 +1778,7 @@ function drawLevelComplete(){
   ctx.textAlign='center';
   ctx.textBaseline='middle';
   ctx.fillStyle=COLORS.hud;
-  ctx.translate(WIDTH/2, HEIGHT/2 - 80);
+  ctx.translate(WIDTH/2, HEIGHT/2 - 120);
   ctx.scale(scale, scale);
   ctx.font='bold 44px system-ui, sans-serif';
   ctx.fillText(msg, 0, 0);
@@ -1789,7 +1789,7 @@ function drawLevelComplete(){
   ctx.strokeStyle = `rgba(180,220,255,${1 - t/animDuration})`;
   ctx.lineWidth = 4;
   ctx.beginPath();
-  ctx.arc(WIDTH/2, HEIGHT/2 - 80, t*60, 0, Math.PI*2);
+  ctx.arc(WIDTH/2, HEIGHT/2 - 120, t*60, 0, Math.PI*2);
   ctx.stroke();
   ctx.restore();
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,12 @@
       navigator.serviceWorker.register('service-worker.js');
     }
 
+    if (screen.orientation && screen.orientation.lock) {
+      screen.orientation.lock('landscape').catch(err => {
+        console.warn('Orientation lock failed:', err);
+      });
+    }
+
     let deferredPrompt;
     const installBtn = document.getElementById('installBtn');
     window.addEventListener('beforeinstallprompt', (e) => {

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "description": "Wave System Edition of Space Mini shooter.",
   "start_url": "index.html",
   "display": "standalone",
+  "orientation": "landscape",
   "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [


### PR DESCRIPTION
## Summary
- Raise level complete menu heading for clearer spacing
- Lock game to landscape orientation and request orientation lock on load
- Restrict Android build to landscape mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ede953e608333bf51183414d1a107