### PR TITLE
Extend startup animation duration

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,12 +26,12 @@ canvas { background:#000; display:block; border-radius:16px; box-shadow:
   color:#fff;
   font:32px system-ui, sans-serif;
   z-index:1000;
-  animation:start-fade 2s forwards;
+  animation:start-fade 4s forwards;
   pointer-events:none;
 }
 @keyframes start-fade {
   0% { opacity:1; }
-  70% { opacity:1; }
+  85% { opacity:1; }
   100% { opacity:0; visibility:hidden; }
 }
 


### PR DESCRIPTION
## Summary
- Lengthen startup splash by running fade-out animation over four seconds
- Preserve brief fade-out by adjusting keyframe to keep element visible longer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ef04f69a083338b3ae0103bc030ed