### PR TITLE
Add glowing miniboss sprite and CSS

### DIFF
--- a/assets/miniboss-ship.svg
+++ b/assets/miniboss-ship.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- main hull -->
+  <path d="M48 10 L60 36 L60 56 L72 64 L76 84 L48 74 L20 84 L24 64 L36 56 L36 36 Z"
+        stroke="#FF3B3B" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- cockpit -->
+  <path d="M48 18 L54 34 L42 34 Z" stroke="#FF3B3B" stroke-width="4" stroke-linejoin="round"/>
+  <!-- wing cutouts -->
+  <path d="M36 44 L30 52 M60 44 L66 52" stroke="#FF3B3B" stroke-width="4" stroke-linecap="round"/>
+  <!-- center panel -->
+  <path d="M48 40 L48 56" stroke="#FF3B3B" stroke-width="4" stroke-linecap="round"/>
+  <!-- thrusters -->
+  <path d="M36 64 L32 74 M60 64 L64 74 M48 66 L48 76" stroke="#FF3B3B" stroke-width="4" stroke-linecap="round"/>
+  <!-- aura ticks -->
+  <g stroke="#FF3B3B" stroke-width="4" stroke-linecap="round" opacity="0.9">
+    <path d="M48 4 v6"/>
+    <path d="M21 17 l5 4"/>
+    <path d="M75 17 l-5 4"/>
+    <path d="M12 40 h6"/>
+    <path d="M84 40 h-6"/>
+  </g>
+</svg>

--- a/game.js
+++ b/game.js
@@ -9,6 +9,19 @@ let keys = new Set();
 let lastShotAt = -999, elapsed = 0;
 let score = 0, best = 0, timeAccumulator = 0, lastFrame = 0;
 
+// image cache for sprites
+const images = {};
+function getImage(path){
+  if (!images[path]){
+    const img = new Image();
+    img.src = path;
+    images[path] = img;
+  }
+  return images[path];
+}
+
+const MINIBOSS_IMG = 'assets/miniboss-ship.svg';
+
 // Wave System
 let currentLevel = 1, currentWave = 1;
 let waveEnemiesKilled = 0, waveEnemiesTotal = 0;
@@ -918,12 +931,55 @@ function render(){
   drawScanlines();
 }
 
+function drawMiniboss(ctx,x,y,t){
+  const ship = getImage(MINIBOSS_IMG);
+  const scale = 1.6;
+  const w = 48 * scale;
+  const h = 48 * scale;
+  const bob = Math.sin(t * 2.2) * 2;
+  ctx.save();
+  ctx.translate(x, y + bob);
+  ctx.shadowColor = '#ff3b3b';
+  ctx.shadowBlur = 24;
+  ctx.globalAlpha = 0.98;
+  if (ship.complete) ctx.drawImage(ship, -w/2, -h/2, w, h);
+
+  // aura ticks
+  ctx.shadowBlur = 0;
+  ctx.globalAlpha = 0.9;
+  ctx.strokeStyle = '#ff3b3b';
+  ctx.lineWidth = 2;
+  const r = Math.min(w, h) * 0.65;
+  for (let i = 0; i < 7; i++){
+    const a = (i / 7) * Math.PI * 2 + (t * 0.6);
+    const x1 = Math.cos(a) * (r + 6);
+    const y1 = Math.sin(a) * (r + 6);
+    const x2 = Math.cos(a) * (r + 16);
+    const y2 = Math.sin(a) * (r + 16);
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 function drawEnemy(enemy){
+  if (enemy.type === 'MINIBOSS'){
+    drawMiniboss(ctx, enemy.x, enemy.y, elapsed);
+    const barW = 60, barH = 6;
+    const pct = enemy.hp / enemy.maxHp;
+    ctx.fillStyle = 'rgba(60,0,0,0.8)';
+    ctx.fillRect(enemy.x - barW/2, enemy.y - enemy.size - 15, barW, barH);
+    ctx.fillStyle = '#f44';
+    ctx.fillRect(enemy.x - barW/2, enemy.y - enemy.size - 15, barW * pct, barH);
+    return;
+  }
   ctx.save();
   ctx.translate(enemy.x, enemy.y);
 
   // Add badass aura for bosses
-  const isBoss = enemy.type === 'MINIBOSS' || enemy.type.startsWith('BOSS');
+  const isBoss = enemy.type.startsWith('BOSS');
   if (isBoss){
     // Pulsating glow
     const pulse = 1 + Math.sin(elapsed * 4) * 0.1;
@@ -1596,6 +1652,11 @@ function drawInfoPowerups(){
 }
 
 function drawBossPreview(type,x,y){
+  if (type === 'MINIBOSS'){
+    const t = Date.now()/1000;
+    drawMiniboss(ctx, x, y, t);
+    return;
+  }
   const info = ENEMY_TYPES[type];
   const size = info.size, color = info.color;
   ctx.save();

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Space Mini — Wave System Edition (Fixed)</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="styles/miniboss.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#000000">
 </head>

--- a/styles/miniboss.css
+++ b/styles/miniboss.css
@@ -1,0 +1,27 @@
+:root{
+  --boss-red: #ff3b3b;
+  --boss-glow-1: rgba(255, 59, 59, 0.9);
+  --boss-glow-2: rgba(255, 59, 59, 0.35);
+}
+
+/* reusable glow for SVG or <img> */
+.boss-neon {
+  filter:
+    drop-shadow(0 0 6px var(--boss-glow-1))
+    drop-shadow(0 0 18px var(--boss-glow-2));
+}
+
+/* slow menace pulse */
+@keyframes boss-pulse {
+  0%, 100% { transform: scale(1); filter: drop-shadow(0 0 6px var(--boss-glow-1)) drop-shadow(0 0 18px var(--boss-glow-2)); opacity: 1; }
+  50% { transform: scale(1.04); filter: drop-shadow(0 0 12px var(--boss-glow-1)) drop-shadow(0 0 28px var(--boss-glow-2)); opacity: 0.95; }
+}
+.boss-pulse { animation: boss-pulse 1.8s ease-in-out infinite; }
+
+/* tiny flicker for thrusters when used in-game as <img> */
+@keyframes thruster-flicker {
+  0%, 100% { filter: drop-shadow(0 0 6px var(--boss-glow-1)) drop-shadow(0 0 18px var(--boss-glow-2)); }
+  50% { filter: drop-shadow(0 0 10px var(--boss-glow-1)) drop-shadow(0 0 24px var(--boss-glow-2)); }
+}
+.boss-thrusters { animation: thruster-flicker 0.25s ease-in-out infinite; }
+


### PR DESCRIPTION
## Summary
- Add neon-outline miniboss SVG asset
- Style miniboss icon with glow and pulse animations
- Render miniboss using SVG with image caching and update boss preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689efbc6a3b88333935ffdb37811f0db